### PR TITLE
cortexm_common/cpu_check_address: fixup for asm statement.

### DIFF
--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -106,15 +106,19 @@ bool cpu_check_address(volatile const char *address)
     /* Cortex-M0 doesn't have BusFault so we need to catch HardFault */
     (void)address;
 
-    /* R5 will be set to 0 by HardFault handler */
-    /* to indicate HardFault has occured */
-    register uint32_t result __asm("r5") = 1;
+    bool result;
 
     __asm__ volatile (
+        "movs r5, #1            \n" /* R5 will be set to 0 by HardFault handler */
+                                    /* to indicate HardFault has occured */
         "ldr  r1, =0xDEADF00D   \n" /* set magic number     */
         "ldr  r2, =0xCAFEBABE   \n" /* 2nd magic to be sure */
-        "ldrb r3, [r0]          \n" /* probe address        */
-    );
+        "ldrb r3, %1            \n" /* probe address        */
+        "mov  %0, r5            \n" /* store result */
+        : "=r"(result)
+        : "m"(*address)
+        : "r1", "r2", "r3", "r5", "cc"
+     );
 
     return result;
 #endif


### PR DESCRIPTION
To prevent GCC/Clang from optimizing away what it should not, the best way is to use Inputs, Outputs and Clobbers to tell it exacly what we are doing.

With this change the code works again in cortex-m0.

For more information see:

https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html#Extended-Asm

Objdump show the following asm being generated (gcc):

```
00000000 <cpu_check_address>:

bool cpu_check_address(volatile const char *address)
{
   0:	b520      	push	{r5, lr}
    /* Cortex-M0 doesn't have BusFault so we need to catch HardFault */
    (void)address;

    bool result;

    __asm__ volatile (
   2:	2501      	movs	r5, #1
   4:	4902      	ldr	r1, [pc, #8]	; (10 <cpu_check_address+0x10>)
   6:	4a03      	ldr	r2, [pc, #12]	; (14 <cpu_check_address+0x14>)
   8:	7803      	ldrb	r3, [r0, #0]
   a:	1c28      	adds	r0, r5, #0
   c:	b2c0      	uxtb	r0, r0
        : "r1", "r2", "r3", "r5"
     );

    return result;
}
   e:	bd20      	pop	{r5, pc}
  10:	deadf00d 	.word	0xdeadf00d
  14:	cafebabe 	.word	0xcafebabe
```

In this particular case clang seems to be a bit less smart and also uses r4 and r7.

### Testing

I checked address 0 and 0x08080000 in a samr21. The first one is valid and the second one is not.