### PR TITLE
sys/ztimer: cleanup xtimer_compat.h for 32Bit only

### DIFF
--- a/makefiles/boards/ztimer_only.dep.mk
+++ b/makefiles/boards/ztimer_only.dep.mk
@@ -5,7 +5,7 @@
 # ztimer_xtimer_compat is used.
 
 ifneq (,$(filter xtimer,$(USEMODULE)))
-  ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+  ifeq (,$(filter ztimer_xtimer_compat ztimer64_xtimer_compat,$(USEMODULE)))
     USEMODULE += xtimer_on_ztimer
   endif
 endif

--- a/sys/Kconfig.newlib
+++ b/sys/Kconfig.newlib
@@ -17,6 +17,7 @@ config MODULE_NEWLIB_SYSCALLS_DEFAULT
     bool
     default y
     depends on !HAVE_CUSTOM_NEWLIB_SYSCALLS
+    select MODULE_DIV
     help
         Default implementation of newlib system calls.
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -220,6 +220,9 @@ ifneq (,$(filter newlib,$(USEMODULE)))
   ifeq (,$(filter newlib_syscalls_%,$(USEMODULE)))
     USEMODULE += newlib_syscalls_default
   endif
+  ifneq (,$(filter newlib_syscalls_default,$(USEMODULE)))
+    USEMODULE += div
+  endif
 endif
 
 ifneq (,$(filter posix_select,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -798,7 +798,8 @@ ifneq (,$(filter xtimer,$(USEMODULE)))
       # will use *ztimer_usec as low-level timer*
     endif
   else
-  # ztimer_xtimer_compat is used, all of *xtimer's API will be mapped on ztimer.*
+    # ztimer_xtimer_compat is used, all of *xtimer's API will be mapped on ztimer
+    # or ztimer64 *
   endif
 endif
 

--- a/sys/event/timeout.c
+++ b/sys/event/timeout.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 Inria
+ *               2017 Freie Universität Berlin
+ *               2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "kernel_defines.h"
+#include "event/timeout.h"
+#if IS_USED(MODULE_ZTIMER64_USEC) && !IS_USED(MODULE_XTIMER)
+#include "ztimer/xtimer_compat.h"
+#else
+#include "xtimer.h"
+#endif
+
+static void _event_timeout_callback(void *arg)
+{
+    event_timeout_t *event_timeout = (event_timeout_t *)arg;
+
+    event_post(event_timeout->queue, event_timeout->event);
+}
+
+void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue, event_t *event)
+{
+    event_timeout->timer.callback = _event_timeout_callback;
+    event_timeout->timer.arg = event_timeout;
+    event_timeout->queue = queue;
+    event_timeout->event = event;
+}
+
+void event_timeout_set(event_timeout_t *event_timeout, uint32_t timeout)
+{
+    xtimer_set(&event_timeout->timer, timeout);
+}
+
+void event_timeout_clear(event_timeout_t *event_timeout)
+{
+    xtimer_remove(&event_timeout->timer);
+}

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -39,12 +39,13 @@
 #include "sched.h"
 #include "rmutex.h"
 
-#ifdef MODULE_ZTIMER_XTIMER_COMPAT
+#if IS_USED(MODULE_ZTIMER64_XTIMER_COMPAT)
+#include "ztimer64/xtimer_compat.h"
+#elif IS_USED(MODULE_ZTIMER_XTIMER_COMPAT)
 #include "ztimer/xtimer_compat.h"
 #else
-
 #include "board.h"
-#ifndef MODULE_XTIMER_ON_ZTIMER
+#if !IS_USED(MODULE_XTIMER_ON_ZTIMER)
 #include "periph_conf.h"
 #endif
 

--- a/sys/include/ztimer64.h
+++ b/sys/include/ztimer64.h
@@ -66,6 +66,7 @@
 
 #include <stdint.h>
 
+#include "irq.h"
 #include "mutex.h"
 #include "msg.h"
 #include "ztimer.h"

--- a/sys/include/ztimer64/xtimer_compat.h
+++ b/sys/include/ztimer64/xtimer_compat.h
@@ -10,14 +10,14 @@
  * @ingroup   sys_ztimer_util
  * @{
  * @file
- * @brief   ztimer xtimer wrapper interface
+ * @brief   ztimer64 xtimer wrapper interface
  *
  * Please check out xtimer's documentation for usage.
  *
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef ZTIMER_XTIMER_COMPAT_H
-#define ZTIMER_XTIMER_COMPAT_H
+#ifndef ZTIMER64_XTIMER_COMPAT_H
+#define ZTIMER64_XTIMER_COMPAT_H
 
 #include <assert.h>
 #include <stdbool.h>
@@ -35,6 +35,7 @@
 #include "sched.h"
 
 #include "ztimer.h"
+#include "ztimer64.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,9 +56,23 @@ extern "C" {
 #define XTIMER_WIDTH    (32)
 #define XTIMER_MASK     (0)
 
-typedef ztimer_t xtimer_t;
+/**
+ * a default XTIMER_BACKOFF value, this is not used by ztimer, but other code
+ * uses this value to set timers
+ */
+#ifndef XTIMER_BACKOFF
+#define XTIMER_BACKOFF  1
+#endif
+
+typedef ztimer64_t xtimer_t;
 typedef uint32_t xtimer_ticks32_t;
 typedef uint64_t xtimer_ticks64_t;
+typedef void (*xtimer_callback_t)(void *);
+
+static inline void xtimer_init(void)
+{
+    ztimer64_init();
+}
 
 static inline xtimer_ticks32_t xtimer_ticks(uint32_t ticks)
 {
@@ -66,58 +81,53 @@ static inline xtimer_ticks32_t xtimer_ticks(uint32_t ticks)
 
 static inline xtimer_ticks32_t xtimer_now(void)
 {
-    return ztimer_now(ZTIMER_USEC);
+    return ztimer64_now(ZTIMER64_USEC);
+}
+
+static inline uint32_t _xtimer_now(void)
+{
+    return ztimer64_now(ZTIMER64_USEC);
 }
 
 static inline xtimer_ticks64_t xtimer_now64(void)
 {
-    return ztimer_now(ZTIMER_USEC);
+    return ztimer64_now(ZTIMER64_USEC);
 }
 
-/*static void xtimer_now_timex(timex_t *out) {
-   }*/
+
+static inline void xtimer_usleep64(uint64_t microseconds)
+{
+    ztimer64_sleep(ZTIMER64_USEC, microseconds);
+}
 
 static inline uint32_t xtimer_now_usec(void)
 {
-    return ztimer_now(ZTIMER_USEC);
+    return ztimer64_now(ZTIMER64_USEC);
 }
 
 static inline uint64_t xtimer_now_usec64(void)
 {
-    return ztimer_now(ZTIMER_USEC);
-}
-
-static inline void _ztimer_sleep_scale(ztimer_clock_t *clock, uint32_t time,
-                                       uint32_t scale)
-{
-    const uint32_t max_sleep = UINT32_MAX / scale;
-
-    while (time > max_sleep) {
-        ztimer_sleep(clock, max_sleep * scale);
-        time -= max_sleep;
-    }
-
-    ztimer_sleep(clock, time * scale);
+    return ztimer64_now(ZTIMER64_USEC);
 }
 
 static inline void xtimer_sleep(uint32_t seconds)
 {
-    /* TODO: use ZTIMER_SEC */
-    if (IS_ACTIVE(MODULE_ZTIMER_MSEC)) {
-        _ztimer_sleep_scale(ZTIMER_MSEC, seconds, 1000);
+    /* TODO: use ZTIMER64_SEC */
+    if (IS_ACTIVE(MODULE_ZTIMER64_MSEC)) {
+        ztimer64_sleep(ZTIMER64_MSEC, ((uint64_t)seconds) * 1000LLU);
     }
     else {
-        _ztimer_sleep_scale(ZTIMER_USEC, seconds, 1000000);
+        ztimer64_sleep(ZTIMER64_USEC, ((uint64_t)seconds) * 1000000LLU);
     }
 }
 
 static inline void xtimer_msleep(uint32_t milliseconds)
 {
     if (IS_ACTIVE(MODULE_ZTIMER_MSEC)) {
-        ztimer_sleep(ZTIMER_MSEC, milliseconds);
+        ztimer_sleep(ZTIMER_USEC, milliseconds);
     }
     else {
-        _ztimer_sleep_scale(ZTIMER_USEC, milliseconds, 1000);
+        ztimer64_sleep(ZTIMER64_USEC, ((uint64_t)milliseconds) * 1000LLU);
     }
 }
 
@@ -133,18 +143,23 @@ static inline void xtimer_nanosleep(uint32_t nanoseconds)
 
 static inline void xtimer_set(xtimer_t *timer, uint32_t offset)
 {
-    ztimer_set(ZTIMER_USEC, timer, offset);
+    ztimer64_set(ZTIMER64_USEC, timer, offset);
 }
 
 static inline void xtimer_remove(xtimer_t *timer)
 {
-    ztimer_remove(ZTIMER_USEC, timer);
+    ztimer64_remove(ZTIMER64_USEC, timer);
+}
+
+static inline bool xtimer_is_set(const xtimer_t *timer)
+{
+    return ztimer64_is_set(timer);
 }
 
 static inline void xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg,
                                   kernel_pid_t target_pid)
 {
-    ztimer_set_msg(ZTIMER_USEC, timer, offset, msg, target_pid);
+    ztimer64_set_msg(ZTIMER64_USEC, timer, offset, msg, target_pid);
 }
 
 static inline void xtimer_periodic_wakeup(xtimer_ticks32_t *last_wakeup,
@@ -179,28 +194,35 @@ static inline int xtimer_msg_receive_timeout(msg_t *msg, uint32_t timeout)
 static inline void xtimer_set_wakeup(xtimer_t *timer, uint32_t offset,
                                      kernel_pid_t pid)
 {
-    ztimer_set_wakeup(ZTIMER_USEC, timer, offset, pid);
+    ztimer64_set_wakeup(ZTIMER64_USEC, timer, offset, pid);
 }
 
 static inline int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us)
 {
-    assert(us <= UINT32_MAX);
-    if (ztimer_mutex_lock_timeout(ZTIMER_USEC, mutex, (uint32_t)us)) {
+    if (ztimer64_mutex_lock_timeout(ZTIMER64_USEC, mutex, us)) {
         /* Impedance matching required: Convert -ECANCELED error code to -1: */
         return -1;
     }
     return 0;
 }
 
-static inline void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout)
+static inline int xtimer_rmutex_lock_timeout(rmutex_t *rmutex, uint64_t timeout)
 {
-    ztimer_set_timeout_flag(ZTIMER_USEC, t, timeout);
+    if (ztimer64_rmutex_lock_timeout(ZTIMER64_USEC, rmutex, timeout)) {
+        /* Impedance matching required: Convert -ECANCELED error code to -1: */
+        return -1;
+    }
+    return 0;
 }
 
 static inline void xtimer_set_timeout_flag64(xtimer_t *t, uint64_t timeout)
 {
-    assert(timeout <= UINT32_MAX);
-    xtimer_set_timeout_flag(t, timeout);
+    ztimer64_set_timeout_flag(ZTIMER64_USEC, t, timeout);
+}
+
+static inline void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout)
+{
+    xtimer_set_timeout_flag64(t, timeout);
 }
 
 static inline void xtimer_spin(xtimer_ticks32_t ticks)
@@ -246,22 +268,40 @@ static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b)
     return a < b;
 }
 
-/*
-   static inline void xtimer_set64(xtimer_t *timer, uint64_t offset_us);
-   static inline void xtimer_tsleep32(xtimer_ticks32_t ticks);
-   static inline void xtimer_tsleep64(xtimer_ticks64_t ticks);
-   static inline void xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset,
-                                       kernel_pid_t pid);
-   static inline xtimer_ticks32_t xtimer_ticks_from_usec(uint32_t usec);
-   static inline xtimer_ticks64_t xtimer_ticks_from_usec64(uint64_t usec);
-   static inline uint32_t xtimer_usec_from_ticks(xtimer_ticks32_t ticks);
-   static inline uint64_t xtimer_usec_from_ticks64(xtimer_ticks64_t ticks);
- #if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
-   static inline void xtimer_set_msg64(xtimer_t *timer, uint64_t offset,
-                                    msg_t *msg, kernel_pid_t target_pid);
-   static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout);
- #endif
- */
+static inline void xtimer_set64(xtimer_t *timer, uint64_t offset_us)
+{
+    ztimer64_set(ZTIMER64_USEC, timer, offset_us);
+}
+
+static inline void xtimer_tsleep32(xtimer_ticks32_t ticks)
+{
+    ztimer_sleep(ZTIMER_USEC, ticks);
+}
+
+static inline void xtimer_tsleep64(xtimer_ticks64_t ticks)
+{
+    ztimer64_sleep(ZTIMER64_USEC, ticks);
+}
+
+static inline void xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset,
+                                       kernel_pid_t pid)
+{
+    ztimer64_set_wakeup(ZTIMER64_USEC, timer, offset, pid);
+}
+
+#if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
+static inline void xtimer_set_msg64(xtimer_t *timer, uint64_t offset,
+                                    msg_t *msg, kernel_pid_t target_pid)
+{
+    ztimer64_set_msg(ZTIMER64_USEC, timer, offset, msg, target_pid);
+}
+
+static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout)
+{
+    return ztimer64_msg_receive_timeout(ZTIMER64_SEC, msg, timeout);
+}
+
+#endif
 
 #endif /* DOXYGEN */
 
@@ -270,4 +310,4 @@ static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b)
 #endif
 
 /** @} */
-#endif /* ZTIMER_XTIMER_COMPAT_H */
+#endif /* ZTIMER64_XTIMER_COMPAT_H */

--- a/sys/xtimer/Kconfig
+++ b/sys/xtimer/Kconfig
@@ -9,9 +9,8 @@ menuconfig MODULE_XTIMER
     bool "xtimer"
     depends on HAS_PERIPH_TIMER
     depends on TEST_KCONFIG
-
     # use timer peripheral unless ztimer compatibility module is used
-    select MODULE_PERIPH_TIMER if HAS_PERIPH_TIMER && !MODULE_XTIMER_ON_ZTIMER && !MODULE_ZTIMER_XTIMER_COMPAT
+    select MODULE_PERIPH_TIMER if HAS_PERIPH_TIMER && !MODULE_XTIMER_ON_ZTIMER && !MODULE_ZTIMER_XTIMER_COMPAT && !MODULE_ZTIMER64_XTIMER_COMPAT
 
     select MODULE_DIV if !MODULE_ZTIMER_XTIMER_COMPAT
     help

--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -141,11 +141,12 @@ menu "xtimer and evtimer compatibility"
 
 choice
     bool "xtimer compatibility"
-    depends on MODULE_XTIMER && MODULE_ZTIMER && MODULE_ZTIMER_PERIPH_TIMER
+    depends on MODULE_XTIMER && MODULE_ZTIMER
 
 config MODULE_XTIMER_ON_ZTIMER
     bool "ztimer_usec as timer backend for xtimer"
     select MODULE_ZTIMER_USEC
+    select MODULE_ZTIMER_PERIPH_TIMER
 
 config MODULE_ZTIMER_XTIMER_COMPAT
     bool "map xtimer calls to ztimer"
@@ -155,15 +156,23 @@ config MODULE_ZTIMER_XTIMER_COMPAT
         This is a wrapper of xtimer API on ztimer_usec and is currently
         incomplete. Unless doing testing, use xtimer on ztimer.
 
+comment "The ztimer xtimer compatibility module is incomplete, consider using MODULE_ZTIMER64_XTIMER_COMPAT instead."
+    depends on MODULE_ZTIMER_XTIMER_COMPAT
+
 endchoice
 
-comment "The ztimer xtimer compatibility module is incomplete, consider using MODULE_XTIMER_ON_ZTIMER instead."
+config MODULE_ZTIMER64_XTIMER_COMPAT
+    bool "map xtimer calls to ztimer64"
+    select MODULE_DIV
+    select MODULE_ZTIMER64
+    select MODULE_ZTIMER64_USEC
     depends on MODULE_ZTIMER_XTIMER_COMPAT
+    help
+        This is a wrapper of xtimer API on ztimer64_usec.
 
 config MODULE_EVTIMER_ON_ZTIMER
     bool "Use ztimer_msec as timer backend for evtimer"
     depends on MODULE_ZTIMER_MSEC
-    select MODULE_ZTIMER_NOW64
 
 endmenu # xtimer compatibility
 

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -12,15 +12,26 @@ ifneq (,$(filter ztimer,$(USEMODULE)))
 endif
 
 # unless ztimer_xtimer_compat is used, make xtimer use ztimer_usec as backend.
-ifneq (,$(filter ztimer_periph_timer,$(USEMODULE)))
-  ifneq  (,$(filter xtimer,$(USEMODULE)))
-    ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+ifneq (,$(filter ztimer,$(USEMODULE)))
+  ifneq (,$(filter xtimer,$(USEMODULE)))
+    ifeq (,$(filter ztimer_xtimer_compat ztimer64_xtimer_compat,$(USEMODULE)))
       USEMODULE += xtimer_on_ztimer
+    else
+      USEMODULE += div
     endif
   endif
   ifneq (,$(filter evtimer,$(USEMODULE)))
     USEMODULE += evtimer_on_ztimer
   endif
+endif
+
+ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+  USEMODULE += ztimer_usec
+endif
+
+ifneq (,$(filter ztimer64_xtimer_compat,$(USEMODULE)))
+  USEMODULE += ztimer64_usec
+  USEMODULE += ztimer_xtimer_compat
 endif
 
 # make xtimer use ztimer_usec as low level timer
@@ -31,13 +42,6 @@ endif
 # make evtimer use ztimer_msec as low level timer
 ifneq (,$(filter evtimer_on_ztimer,$(USEMODULE)))
   USEMODULE += ztimer_msec
-endif
-
-# "ztimer_xtimer_compat" is a wrapper of the xtimer API on ztimer_used
-# (it is currently incomplete). Unless doing testing, use "xtimer_on_ztimer".
-ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-  USEMODULE += div
-  USEMODULE += ztimer_usec
 endif
 
 ifneq (,$(filter ztimer_%,$(USEMODULE)))

--- a/tests/xtimer_drift/Makefile
+++ b/tests/xtimer_drift/Makefile
@@ -1,5 +1,6 @@
 include ../Makefile.tests_common
 
 USEMODULE += xtimer
+USEMODULE += div
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_drift/app.config.test
+++ b/tests/xtimer_drift/app.config.test
@@ -1,3 +1,4 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_XTIMER=y
+CONFIG_MODULE_DIV=y


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
